### PR TITLE
Added queue thread-safety via a semaphore class

### DIFF
--- a/src/__tests__/eventLogger-test.js
+++ b/src/__tests__/eventLogger-test.js
@@ -531,7 +531,6 @@ describe('createEventLogger middleware tests', () => {
       .reply(200);
 
     const retVal1 = await middleware(dummyStore)(next)(action1);
-    await sleep(1);
     const retVal2 = await middleware(dummyStore)(next)(action2);
     // this is after the middlware is actually executed
     expect(retVal1).toBe(action1);


### PR DESCRIPTION
Will allow for timeouts (currently will just hang if there are any bugs) and safer failures (log an error to the console instead of throwing an error) in a future PR.