### PR TITLE
Improved the locking mechanism

### DIFF
--- a/src/Semaphore.js
+++ b/src/Semaphore.js
@@ -1,0 +1,52 @@
+/* @flow */
+
+export default class Semaphore {
+  queue: Array<Function>;
+  count: number;
+  max: number;
+
+  constructor(max: number) {
+    this.queue = [];
+    this.max = max;
+    this.count = 0;
+  }
+
+  async acquire(maxWaitMillis: number = -1): Promise<boolean> {
+    if (this.count < this.max) {
+      this.count++;
+      return Promise.resolve(true);
+    }
+
+    if (maxWaitMillis > 0) {
+      // dummyResolver starts out as a true 'dummy' resolve function
+      let dummyResolver = () => { };
+      const promise = new Promise(r => {
+        dummyResolver = r;
+      });
+      this.queue.push(dummyResolver);
+      setTimeout(() => {
+        const index = this.queue.indexOf(dummyResolver);
+        if (index >= 0) {
+          this.queue.splice(index, 1);
+        }
+        dummyResolver(false);
+      }, maxWaitMillis);
+
+      return promise;
+    } else {
+      return new Promise(resolve => {
+        this.queue.push(resolve);
+      });
+    }
+  }
+  release() : void {
+    if (this.queue.length > 0) {
+      const next = this.queue.shift();
+      if (next !== null) {
+        next(true);
+      }
+    }
+      
+    this.count--;
+  }
+}

--- a/src/__tests__/semaphore-test.js
+++ b/src/__tests__/semaphore-test.js
@@ -1,0 +1,128 @@
+'use strict';
+
+import Semaphore  from '../Semaphore.js';
+
+const sleep = function(timeout) {
+  return new Promise((resolve) => {
+    setTimeout(resolve, timeout);
+  });
+};
+
+describe('Semaphore validation tests', () => {
+  test('1-slot semaphore', async () => {
+    const sem = new Semaphore(1);
+    let counter = 0;
+
+    const fn = () => {
+      sem.acquire().then(() => { counter++; });
+    };
+    fn();
+    fn();
+
+    await sleep(1);
+
+    expect(counter).toEqual(1);
+  });
+  test('3-slot semaphore where we fill up the slots', async () => {
+    const sem = new Semaphore(3);
+    let counter = 0;
+
+    const fn = () => {
+      sem.acquire().then(() => { counter++; });
+    };
+    fn();
+    fn();
+    fn();
+    fn();
+
+    await sleep(1);
+
+    expect(counter).toEqual(3);
+  });
+  test('3-slot semaphore where we play nice and release', async () => {
+    const sem = new Semaphore(3);
+    let counter = 0;
+
+    const fn = () => {
+      sem.acquire().then(() => { counter++; sem.release(); });
+    };
+    fn();
+    fn();
+    fn();
+    fn();
+    fn();
+
+    await sleep(1);
+
+    expect(counter).toEqual(5);
+  });
+  test('3-slot semaphore with timeouts but no releasing', async () => {
+    const sem = new Semaphore(3);
+    let successCounter = 0;
+    let overallCounter = 0;
+
+    const fn = () => {
+      sem.acquire(2).then((hasLock) => { 
+        overallCounter++;
+        if (hasLock) successCounter++; 
+      });
+    };
+    fn();
+    fn();
+    fn();
+    fn();
+    fn();
+
+    await sleep(250);
+
+    expect(overallCounter).toEqual(5);
+    expect(successCounter).toEqual(3);
+  });
+  test('3-slot semaphore with timeouts', async () => {
+    const sem = new Semaphore(3);
+    let successCounter = 0;
+    let overallCounter = 0;
+
+    const fn = () => {
+      sem.acquire(10).then((hasLock) => { 
+        overallCounter++;
+        if (hasLock) successCounter++;
+        sem.release();
+      });
+    };
+    fn();
+    fn();
+    fn();
+    fn();
+    fn();
+
+    await sleep(250);
+
+    expect(overallCounter).toEqual(5);
+    expect(successCounter).toEqual(5);
+  });
+  test('3-slot semaphore with timeouts', async () => {
+    const sem = new Semaphore(3);
+    let successCounter = 0;
+    let overallCounter = 0;
+
+    const fn = () => {
+      sem.acquire(10).then(async (hasLock) => { 
+        overallCounter++;
+        if (hasLock) successCounter++;
+        await sleep(12); // wait longer than the given acquire timeout
+        sem.release();
+      });
+    };
+    fn();
+    fn();
+    fn();
+    fn();
+    fn();
+
+    await sleep(250);
+
+    expect(overallCounter).toEqual(5);
+    expect(successCounter).toEqual(3);
+  });
+});


### PR DESCRIPTION
* Pulled Semaphore out into its own file and added unit tests
* Modified acquire() to allow for a timeout in milliseconds. If the
acquire can’t happen within the given timeout it will return with
`false`. If no timeout is given then it will wait forever.
* Modified the LargeItemLocalQueue class to wait just 20ms for lock
acquisition. If it fails then we log an error to the console and
silently fail.